### PR TITLE
Fixed scroll on news page

### DIFF
--- a/src/news/news.html
+++ b/src/news/news.html
@@ -33,6 +33,7 @@
       position: fixed;
       width: 100%;
       height: 100%;
+      overflow-x: auto;
     }
 
     div#news>iframe {


### PR DESCRIPTION
The News page doesn't have scroll enabled preventing users from seeing more than 4-5 rows at a time!

This PR fixes that problem.